### PR TITLE
Alternative literal expression format.

### DIFF
--- a/typed_sql/example/main.dart
+++ b/typed_sql/example/main.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:typed_sql/src/typed_sql.dart';
 import 'package:typed_sql/typed_sql.dart';
 import 'model.dart';
 
@@ -49,7 +50,7 @@ Future<void> main() async {
     if (user != null) {
       print('${user.email} has liked');
       final queryLikes =
-          db.likes.where((like) => like.userId.equals.literal(user.userId));
+          db.likes.where((like) => like.userId.equals(user.userId.literal));
       await for (final like in queryLikes.fetch()) {
         print(like.packageName);
       }
@@ -65,7 +66,7 @@ Future<void> main() async {
 
   {
     final users = await db.users
-        .where((user) => user.email.endsWith.literal('@google.com'))
+        .where((user) => user.email.endsWith('@google.com'.literal))
         .orderBy((user) => user.email)
         .offset(5)
         .limit(10)
@@ -84,11 +85,11 @@ Future<void> main() async {
   {
     await db.transaction((tx) async {
       await tx.users
-          .where((u) => u.email.endsWith.literal('@google.com'))
+          .where((u) => u.email.endsWith('@google.com'.literal))
           .fetch()
           .toList();
       await tx.likes
-          .where((l) => l.packageName.startsWith.literal('_').not())
+          .where((l) => l.packageName.startsWith('_'.literal).not())
           .fetch()
           .toList();
 

--- a/typed_sql/example/model.dart
+++ b/typed_sql/example/model.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:typed_sql/src/typed_sql.dart';
 import 'package:typed_sql/typed_sql.dart';
 
 part 'model.g.dart';

--- a/typed_sql/example/model.g.dart
+++ b/typed_sql/example/model.g.dart
@@ -73,7 +73,7 @@ extension TableUserExt on Table<User> {
 extension QueryUserExt on Query<User> {
   /// TODO: document lookup by PrimaryKey
   QuerySingle<User> byKey({required int userId}) =>
-      where((user) => user.userId.equals.literal(userId)).first;
+      where((user) => user.userId.equals(userId.literal)).first;
 
   /// TODO: document where()
   Query<User> where(Expr<bool> Function(Expr<User> user) conditionBuilder) =>
@@ -126,7 +126,7 @@ extension QueryUserExt on Query<User> {
 
   /// TODO: document byXXX()}
   QuerySingle<User> byEmail(String email) =>
-      where((user) => user.email.equals.literal(email)).first;
+      where((user) => user.email.equals(email.literal)).first;
 }
 
 extension QuerySingleUserExt on QuerySingle<User> {
@@ -211,7 +211,7 @@ extension TablePackageExt on Table<Package> {
 extension QueryPackageExt on Query<Package> {
   /// TODO: document lookup by PrimaryKey
   QuerySingle<Package> byKey({required String name}) =>
-      where((package) => package.name.equals.literal(name)).first;
+      where((package) => package.name.equals(name.literal)).first;
 
   /// TODO: document where()
   Query<Package> where(
@@ -349,9 +349,9 @@ extension QueryLikeExt on Query<Like> {
     required int userId,
     required String packageName,
   }) =>
-      where((like) => like.userId.equals
-          .literal(userId)
-          .and(like.packageName.equals.literal(packageName))).first;
+      where((like) => like.userId
+          .equals(userId.literal)
+          .and(like.packageName.equals(packageName.literal))).first;
 
   /// TODO: document where()
   Query<Like> where(Expr<bool> Function(Expr<Like> like) conditionBuilder) =>

--- a/typed_sql/lib/src/typed_sql.expression.dart
+++ b/typed_sql/lib/src/typed_sql.expression.dart
@@ -80,6 +80,22 @@ extension DotLiteral<R, T> on R Function(Expr<T>) {
   R literal(T value) => this(Literal(value));
 }
 
+extension BoolLiteral on bool {
+  Literal<bool> get literal => Literal<bool>(this);
+}
+
+extension IntLiteral on int {
+  Literal<int> get literal => Literal<int>(this);
+}
+
+extension DoubleLiteral on double {
+  Literal<double> get literal => Literal<double>(this);
+}
+
+extension StringLiteral on String {
+  Literal<String> get literal => Literal<String>(this);
+}
+
 sealed class BinaryOperationExpression<T, R> extends Expr<R> {
   final Expr<T> left;
   final Expr<T> right;

--- a/typed_sql/test/sqlite/model.dart
+++ b/typed_sql/test/sqlite/model.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:typed_sql/src/typed_sql.dart';
 import 'package:typed_sql/typed_sql.dart';
 
 part 'model.g.dart';

--- a/typed_sql/test/sqlite/model.g.dart
+++ b/typed_sql/test/sqlite/model.g.dart
@@ -64,7 +64,7 @@ extension TableUserExt on Table<User> {
 extension QueryUserExt on Query<User> {
   /// TODO: document lookup by PrimaryKey
   QuerySingle<User> byKey({required int userId}) =>
-      where((user) => user.userId.equals.literal(userId)).first;
+      where((user) => user.userId.equals(userId.literal)).first;
 
   /// TODO: document where()
   Query<User> where(Expr<bool> Function(Expr<User> user) conditionBuilder) =>
@@ -122,7 +122,7 @@ extension QueryUserExt on Query<User> {
 
   /// TODO: document byXXX()}
   QuerySingle<User> byEmail(String email) =>
-      where((user) => user.email.equals.literal(email)).first;
+      where((user) => user.email.equals(email.literal)).first;
 }
 
 extension QuerySingleUserExt on QuerySingle<User> {

--- a/typed_sql/test/sqlite/sqlite_test.dart
+++ b/typed_sql/test/sqlite/sqlite_test.dart
@@ -14,6 +14,7 @@
 
 import 'package:test/test.dart';
 import 'package:typed_sql/sql_dialect/sql_dialect.dart';
+import 'package:typed_sql/src/typed_sql.dart';
 import 'model.dart';
 import 'package:typed_sql/typed_sql.dart';
 
@@ -67,7 +68,7 @@ void main() {
     print(users);
 
     final alice = await db.users
-        .where((u) => u.name.equals.literal('Alice'))
+        .where((u) => u.name.equals('Alice'.literal))
         .first
         .fetch();
     print(alice);


### PR DESCRIPTION
I think `<x>.literal` (or maybe `<x>.asExpr()` or `<x>.expr`) reads slightly more natural, but we may provide both options.