### PR TITLE
Postgres adaptor without the transaction savepoint.

### DIFF
--- a/typed_sql/lib/adaptor/adaptor.dart
+++ b/typed_sql/lib/adaptor/adaptor.dart
@@ -17,7 +17,7 @@ import 'dart:typed_data';
 import 'logging_adaptor.dart';
 import 'sqlite.dart';
 
-abstract base class DatabaseAdaptor extends QueryExecutor {
+abstract class DatabaseAdaptor extends QueryExecutor {
   /// Begin a transaction ad call [fn] before committing the transaction.
   ///
   /// If [fn] throws, the transaction shall be rolled back and the [Exception]
@@ -38,7 +38,7 @@ abstract base class DatabaseAdaptor extends QueryExecutor {
       loggingAdaptor(adaptor, logDrain);
 }
 
-abstract base class DatabaseTransaction extends QueryExecutor {
+abstract class DatabaseTransaction extends QueryExecutor {
   /// Create a save-point and runs `fn` before releasing the save-point.
   ///
   /// If [fn] throws, this transaction shall be rolled back to the
@@ -62,7 +62,7 @@ class QueryResult {
   });
 }
 
-abstract final class QueryExecutor {
+abstract class QueryExecutor {
   Future<void> script(String sql);
 
   /// Execute [sql] query with positional [params].

--- a/typed_sql/lib/adaptor/postgres_adaptor.dart
+++ b/typed_sql/lib/adaptor/postgres_adaptor.dart
@@ -1,0 +1,107 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:postgres/postgres.dart';
+
+import 'adaptor.dart';
+
+DatabaseAdaptor postgresAdaptor(Pool pool) => _PostgresDatabaseAdaptor(pool);
+
+class _QueryExecutor<S extends Session> extends QueryExecutor {
+  final S _session;
+
+  _QueryExecutor(this._session);
+
+  @override
+  Future<QueryResult> execute(String sql, List<Object?> params) async {
+    final rs = await _session.execute(sql, parameters: params);
+    return QueryResult(
+      affectedRows: rs.affectedRows,
+      rows: rs.map(_PostgresRowReader.new).toList(),
+    );
+  }
+
+  @override
+  Stream<RowReader> query(String sql, List<Object?> params) async* {
+    final ps = await _session.prepare(sql);
+    yield* ps.bind(params).map(_PostgresRowReader.new);
+  }
+
+  @override
+  Future<void> script(String sql) async {
+    await _session.execute(sql, queryMode: QueryMode.simple);
+  }
+}
+
+final class _PostgresDatabaseAdaptor extends _QueryExecutor<Pool>
+    implements DatabaseAdaptor {
+  _PostgresDatabaseAdaptor(super._session);
+
+  @override
+  Future<T> transaction<T>(
+      Future<T> Function(DatabaseTransaction tx) fn) async {
+    return await _session.runTx((tx) async {
+      return await fn(_DatabaseTransaction(tx));
+    });
+  }
+
+  @override
+  Future<void> close({bool force = false}) async {
+    await _session.close(force: force);
+  }
+}
+
+class _DatabaseTransaction extends _QueryExecutor<TxSession>
+    implements DatabaseTransaction {
+  _DatabaseTransaction(super._session);
+
+  @override
+  Future<T> savePoint<T>(Future<T> Function(DatabaseSavePoint sp) fn) {
+    throw UnimplementedError();
+  }
+}
+
+final class _PostgresRowReader extends RowReader {
+  int _i = 0;
+  final ResultRow _row;
+
+  _PostgresRowReader(this._row);
+
+  @override
+  bool? readBool() {
+    return _row[_i++] as bool?;
+  }
+
+  @override
+  DateTime? readDateTime() {
+    return _row[_i++] as DateTime?;
+  }
+
+  @override
+  double? readDouble() {
+    return _row[_i++] as double?;
+  }
+
+  @override
+  int? readInt() {
+    return _row[_i++] as int?;
+  }
+
+  @override
+  String? readString() {
+    return _row[_i++] as String?;
+  }
+}

--- a/typed_sql/pubspec.yaml
+++ b/typed_sql/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   collection: ^1.19.0
   glob: ^2.1.3
   meta: ^1.9.1
+  postgres: ^3.5.4
   source_gen: ">=1.2.2 <3.0.0"
   sqlite3: ^2.7.2
   #build_config: ^1.0.0


### PR DESCRIPTION
Note: removed the `base` class modifiers as the implementation made more sense with mirroring the class structure.